### PR TITLE
distinguish practical kana ranges from strict Unicode kana ranges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,19 +801,22 @@ pub fn is_hiragana(c: char) -> bool {
 }
 
 /// Is a given `char` betwen あ and ゟ?
-/// Strictly compliant with the [unicode definition of hiragana](https://www.unicode.org/charts/PDF/U3040.pdf),
-/// including ponctuation, marks and a digraph
+/// Strictly compliant with the [Unicode definition of hiragana],
+/// including marks and a digraph
 ///
 /// ```
 /// assert!(kanji::is_hiragana_extended('あ'));
 /// assert!(kanji::is_hiragana_extended('ゟ'));
 /// assert!(!kanji::is_hiragana_extended('a'));
 /// ```
+/// 
+/// [Unicode definition of hiragana]: https://www.unicode.org/charts/PDF/U3040.pdf
 pub fn is_hiragana_extended(c: char) -> bool {
     c >= '\u{3041}' && c <= '\u{309f}'
 }
 
 /// Is a given `char` between ァ and ヺ?
+/// Includes the vowel prolongation mark 'ー'.
 ///
 /// ```
 /// assert!(kanji::is_katakana('ン'));
@@ -825,7 +828,7 @@ pub fn is_katakana(c: char) -> bool {
 }
 
 /// Is a given `char` between ゠ and ヿ?
-/// Strictly compliant with the [unicode definition of katakana](https://www.unicode.org/charts/PDF/U30A0.pdf),
+/// Strictly compliant with the [Unicode definition of katakana],
 /// including ponctuation, marks and a digraph
 ///
 /// ```
@@ -833,6 +836,8 @@ pub fn is_katakana(c: char) -> bool {
 /// assert!(kanji::is_katakana_extended('ヿ'));
 /// assert!(!kanji::is_katakana_extended('a'));
 /// ```
+/// 
+/// [Unicode definition of katakana]: https://www.unicode.org/charts/PDF/U30A0.pdf
 pub fn is_katakana_extended(c: char) -> bool {
     c >= '\u{30a0}' && c <= '\u{30ff}'
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,7 +789,7 @@ pub fn is_kanji(c: char) -> bool {
         || (c >= '\u{30000}' && c <= '\u{3134a}') // Extension G
 }
 
-/// Is a given `char` betwen あ and ゖ?
+/// Is a given `char` betwen あ and ゖ (small け)?
 ///
 /// ```
 /// assert!(kanji::is_hiragana('あ'));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,7 +802,7 @@ pub fn is_hiragana(c: char) -> bool {
 
 /// Is a given `char` betwen あ and ゟ?
 /// Strictly compliant with the [Unicode definition of hiragana],
-/// including marks and a digraph
+/// including marks and a digraph.
 ///
 /// ```
 /// assert!(kanji::is_hiragana_extended('あ'));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,7 +821,7 @@ pub fn is_hiragana_extended(c: char) -> bool {
 /// assert!(!kanji::is_katakana('a'));
 /// ```
 pub fn is_katakana(c: char) -> bool {
-    c >= '\u{30a1}' && c <= '\u{30fa}'
+    c >= '\u{30a1}' && c <= '\u{30fa}' || c == '\u{30fc}'
 }
 
 /// Is a given `char` between ゠ and ヿ?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,7 +829,7 @@ pub fn is_katakana(c: char) -> bool {
 
 /// Is a given `char` between ゠ and ヿ?
 /// Strictly compliant with the [Unicode definition of katakana],
-/// including ponctuation, marks and a digraph
+/// including punctuation, marks and a digraph
 ///
 /// ```
 /// assert!(kanji::is_katakana_extended('ン'));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,23 +789,51 @@ pub fn is_kanji(c: char) -> bool {
         || (c >= '\u{30000}' && c <= '\u{3134a}') // Extension G
 }
 
-/// Is a given `char` betwen あ and ん?
+/// Is a given `char` betwen あ and ゖ?
 ///
 /// ```
 /// assert!(kanji::is_hiragana('あ'));
+/// assert!(!kanji::is_hiragana('ゟ'));
 /// assert!(!kanji::is_hiragana('a'));
 /// ```
 pub fn is_hiragana(c: char) -> bool {
+    c >= '\u{3041}' && c <= '\u{3096}'
+}
+
+/// Is a given `char` betwen あ and ゟ?
+/// Strictly compliant with the [unicode definition of hiragana](https://www.unicode.org/charts/PDF/U3040.pdf),
+/// including ponctuation, marks and a digraph
+///
+/// ```
+/// assert!(kanji::is_hiragana_extended('あ'));
+/// assert!(kanji::is_hiragana_extended('ゟ'));
+/// assert!(!kanji::is_hiragana_extended('a'));
+/// ```
+pub fn is_hiragana_extended(c: char) -> bool {
     c >= '\u{3041}' && c <= '\u{309f}'
 }
 
-/// Is a given `char` between ア and ン?
+/// Is a given `char` between ァ and ヺ?
 ///
 /// ```
 /// assert!(kanji::is_katakana('ン'));
+/// assert!(!kanji::is_katakana('ヿ'));
 /// assert!(!kanji::is_katakana('a'));
 /// ```
 pub fn is_katakana(c: char) -> bool {
+    c >= '\u{30a1}' && c <= '\u{30fa}'
+}
+
+/// Is a given `char` between ゠ and ヿ?
+/// Strictly compliant with the [unicode definition of katakana](https://www.unicode.org/charts/PDF/U30A0.pdf),
+/// including ponctuation, marks and a digraph
+///
+/// ```
+/// assert!(kanji::is_katakana_extended('ン'));
+/// assert!(kanji::is_katakana_extended('ヿ'));
+/// assert!(!kanji::is_katakana_extended('a'));
+/// ```
+pub fn is_katakana_extended(c: char) -> bool {
     c >= '\u{30a0}' && c <= '\u{30ff}'
 }
 


### PR DESCRIPTION
Hello,

In case PRs are welcome, here's one as I realized that the `is_hiragana` and `is_katakana` functions can give surprising results, e.g.
```
assert!(kanji::is_katakana('・'), false);
assert!(kanji::is_hiragana('ゟ'), false);
assert!(kanji::is_hiragana(' ゚'), false);
```

The reality is even more complex, as more kana-like signs exist out there, see [1](https://www.unicode.org/charts/PDF/U1B130.pdf) [2](https://www.unicode.org/charts/PDF/U31F0.pdf) [3](https://www.unicode.org/charts/PDF/UFF00.pdf), I can gladly attempt to cover these sub-ranges too if there's an interest.

Please let me know if you have any suggestion about the code or the PR in general.